### PR TITLE
tests/read2.c: Fix integer overflow when run on big machine

### DIFF
--- a/tests/read2.c
+++ b/tests/read2.c
@@ -25,7 +25,7 @@ void testcase_prepare(unsigned long nr_tasks)
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
 	char buf[BUFLEN];
-	char fd = open(tmpfile, O_RDONLY);
+	int fd = open(tmpfile, O_RDONLY);
 
 	assert(fd >= 0);
 


### PR DESCRIPTION
In read2 testcase, char (7 bits integer) is used for file descriptor,
when test on a big machine with more than 127 CPUs, the fd will
overflow and trigger assert() failure.  Fixed this via change the type
to integer.