### PR TITLE
create workload to measure tlb flush performance

### DIFF
--- a/tests/tlb_flush1.c
+++ b/tests/tlb_flush1.c
@@ -1,0 +1,41 @@
+#define _GNU_SOURCE             /* See feature_test_macros(7) */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <stdio.h>
+
+#define gettid()  syscall(SYS_gettid)
+#define FILESIZE (128 * 1024 * 1024)
+
+char *testcase_description = "TLB flush of separated file private mapping";
+
+void testcase(unsigned long *iteration, unsigned long nr)
+{
+	printf("thread/process number: %lu, pid: %ld\n", nr, gettid());
+	char tmpfile[] = "/tmpfs/willitscale.XXXXXX";
+	int fd = mkstemp(tmpfile);
+	unsigned long offset = 0;
+	unsigned long pgsize = getpagesize();
+	assert(fd >= 0);
+	assert(ftruncate(fd, FILESIZE) == 0);
+	unlink(tmpfile);
+	unsigned long i;
+
+	while (1) {
+		char *addr = mmap(NULL, FILESIZE, PROT_READ|PROT_WRITE,
+						MAP_PRIVATE, fd, offset);
+		for (i = 0; i < FILESIZE; i += pgsize) {
+			*(addr + i) = 1;
+			madvise(addr + i, pgsize, MADV_DONTNEED);
+			assert(*(addr + i) == 0);
+			(*iteration)++;
+		}
+		munmap(addr, FILESIZE);
+	}
+}

--- a/tests/tlb_flush2.c
+++ b/tests/tlb_flush2.c
@@ -1,0 +1,35 @@
+#define _GNU_SOURCE             /* See feature_test_macros(7) */
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <string.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/syscall.h>
+#include <stdio.h>
+
+#define gettid()  syscall(SYS_gettid)
+#define MEMORYSIZE (1 * 1024 * 1024)
+
+char *testcase_description = "TLB flush of anonymous memory private mapping";
+
+void testcase(unsigned long *iteration, unsigned long nr)
+{
+	printf("thread/process number: %lu, pid: %ld\n", nr, gettid());
+	unsigned long pgsize = getpagesize();
+	unsigned long i;
+
+	while (1) {
+		char *addr = mmap(NULL, MEMORYSIZE, PROT_READ|PROT_WRITE,
+						MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+		for (i = 0; i < MEMORYSIZE; i += pgsize) {
+			*(addr + i) = 1;
+			madvise(addr + i, pgsize, MADV_DONTNEED);
+			assert(*(addr + i) == 0);
+			(*iteration)++;
+		}
+		munmap(addr, MEMORYSIZE);
+	}
+}


### PR DESCRIPTION
  These workload are designed to measure the performance of tlb flush. 
     For tlb flush1 test case, each  thread/process maps a separated private file mapping to memory, and
    writes to a page before initiating a tlb flush by madvise(MADV_DONTNEED),  subsequent access of 
     this page will result in repopulating the memory contents of the up-to-date of the underlying file.
 
    For tlb flush2 test case, each thread/process has an anonymous private mappings, and writes to a 
    page before initiationg a tlb flush by madvise(MADV_DONTNEED), subsequent access
    of this page will result in zero-fill-on-demand pages for anonymous private
    mapping.
    
    Additionally, they are also tlb flush sensitive workload to verify the
    behavior of tlb hardware, the assertion fails immediately once tlb flush
    failure. We have double checked it by hacking Linux kernel to skip tlb
    flush manually.
    
     This work is done with Dave Hansen. These are the best Linux workloads that we have that could
    detect issues with the TLB either in software, or potentially in hardware.
    This could provide validation for the ICX "Split TLB" behavior. 
