### PR TITLE
poll2: update the limitation when the new limitation is bigger than it

### DIFF
--- a/tests/poll2.c
+++ b/tests/poll2.c
@@ -16,10 +16,13 @@ void testcase_prepare(unsigned long nr_tasks)
 {
 	struct rlimit rlim;
 	int nr_procs = sysconf(_SC_NPROCESSORS_CONF);
+	rlim_t new_lim = (NR_FILES + 10) * nr_procs;
 
 	getrlimit(RLIMIT_NOFILE, &rlim);
-	rlim.rlim_cur = (NR_FILES + 10) * nr_procs;
-	rlim.rlim_max = (NR_FILES + 10) * nr_procs;
+	if( rlim.rlim_max < new_lim) {
+		rlim.rlim_cur = new_lim;
+		rlim.rlim_max = new_lim;
+	}
 	assert(setrlimit(RLIMIT_NOFILE, &rlim) == 0);
 }
 


### PR DESCRIPTION
In some case the limitation is set to a very small value, it even smaller
than the old one which will cause "EMFILE" error. For example, when run
"./poll2_threads -t 16 -s 295" on a 4 cpus' machine, the limitation should
 bigger than 128*16=2048, but the new limitation is set to (128+10)*4=552.
So update the limitation only when the new value is bigger than it.

Signed-off-by: Zhengjun Xing <zhengjun.xing@linux.intel.com>