### PR TITLE
pthread_mutex tweaks and python3 conversion

### DIFF
--- a/postprocess.py
+++ b/postprocess.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 
 import sys
 import os
@@ -44,8 +44,8 @@ def process(base):
     t = string.Template(template)
     html = t.substitute(data=data, title=title)
 
-    file(htmlfile, 'w').write(html)
-    print 'Created %s' % (htmlfile)
+    open(htmlfile, 'w').write(html)
+    print('Created %s' % (htmlfile))
 
 
 def for_each_file(dirname, subdirs, filenames):

--- a/runtest.py
+++ b/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import time
 import subprocess
@@ -51,7 +51,7 @@ class linux_stat():
 duration=5
 
 if len(sys.argv) != 2:
-	print >> sys.stderr, 'Usage: runtest.py <testcase>'
+	print('Usage: runtest.py <testcase>', file=sys.stderr)
 	sys.exit(1)
 cmd = sys.argv[1]
 
@@ -66,30 +66,30 @@ fd.close()
 setarch = 'setarch linux64 -R'
 try:
 	retcode = subprocess.call(setarch + " /bin/true", shell=True)
-except OSError, e:
+except OSError as e:
 	retcode = -1
 
 if retcode != 0:
 	setarch = ''
-	print >> sys.stderr, 'WARNING: setarch -R failed, address space randomization may cause variability'
+	print('WARNING: setarch -R failed, address space randomization may cause variability', file=sys.stderr)
 
-pipe = subprocess.Popen('uname -m', shell=True, stdout=subprocess.PIPE).stdout
+pipe = subprocess.Popen('uname -m', shell=True, stdout=subprocess.PIPE, text=True).stdout
 arch = pipe.readline().rstrip(os.linesep)
 pipe.close()
 
 if arch == 'ppc64':
-	pipe = subprocess.Popen('ppc64_cpu --smt 2>&1', shell=True, stdout=subprocess.PIPE).stdout
+	pipe = subprocess.Popen('ppc64_cpu --smt 2>&1', shell=True, stdout=subprocess.PIPE, text=True).stdout
 	smt_status = pipe.readline()
 	pipe.close()
 	if 'off' not in smt_status:
-		print >> sys.stderr, 'WARNING: SMT enabled, suggest disabling'
+		print('WARNING: SMT enabled, suggest disabling', file=sys.stderr)
 
-print 'tasks,processes,processes_idle,threads,threads_idle,linear'
-print '0,0,100,0,100,0'
+print('tasks,processes,processes_idle,threads,threads_idle,linear')
+print('0,0,100,0,100,0')
 
 step = 1
 # if step=5, this is: [5, 10, 15, ... nr_cores]
-data_points = range(step, nr_cores+step, step)
+data_points = list(range(step, nr_cores+step, step))
 # this makes it [ 1, 5, 10, ... ]
 if step > 1:
 	data_points.insert(0, 1)
@@ -97,7 +97,7 @@ if step > 1:
 for i in data_points:
 	c = './%s_processes -t %d -s %d' % (cmd, i, duration)
 	before = linux_stat()
-	pipe = subprocess.Popen(setarch + ' ' + c, shell=True, stdout=subprocess.PIPE).stdout
+	pipe = subprocess.Popen(setarch + ' ' + c, shell=True, stdout=subprocess.PIPE, text=True).stdout
 	processes_avg = -1
 	for line in pipe.readlines():
 		if 'testcase:' in line:
@@ -115,7 +115,7 @@ for i in data_points:
 
 	c = './%s_threads -t %d -s %d' % (cmd, i, duration)
 	before = linux_stat()
-	pipe = subprocess.Popen(setarch + ' ' + c, shell=True, stdout=subprocess.PIPE).stdout
+	pipe = subprocess.Popen(setarch + ' ' + c, shell=True, stdout=subprocess.PIPE, text=True).stdout
 	threads_avg = -1
 	for line in pipe.readlines():
 		if 'average:' in line:
@@ -128,4 +128,4 @@ for i in data_points:
 	if i == 1:
 		linear = max(processes_avg, threads_avg)
 
-	print '%d,%d,%0.2f,%d,%0.2f,%d' % (i, processes_avg, processes_idle, threads_avg, threads_idle, linear * i)
+	print('%d,%d,%0.2f,%d,%0.2f,%d' % (i, processes_avg, processes_idle, threads_avg, threads_idle, linear * i))

--- a/tests/pthread_mutex4.c
+++ b/tests/pthread_mutex4.c
@@ -1,5 +1,6 @@
 #define _GNU_SOURCE
 #include <pthread.h>
+#include <alloca.h>
 
 char *testcase_description = "Contended pthread mutex with local update";
 
@@ -7,11 +8,13 @@ pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
-	unsigned long val;
+	// alloca() because plain "unsigned long val" gets optimized away.
+	unsigned long *val = alloca(sizeof(unsigned long));
+	*(val) = 0;
 
 	while (1) {
 		pthread_mutex_lock(&mutex);
-		val++;
+		(*val)++;
 		pthread_mutex_unlock(&mutex);
 
 		(*iterations)++;

--- a/tests/pthread_mutex5.c
+++ b/tests/pthread_mutex5.c
@@ -1,0 +1,18 @@
+#define _GNU_SOURCE
+#include <pthread.h>
+
+char *testcase_description = "Contended pthread mutex with TLS update";
+
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+__thread unsigned long val;
+
+void testcase(unsigned long long *iterations, unsigned long nr)
+{
+	while (1) {
+		pthread_mutex_lock(&mutex);
+		val++;
+		pthread_mutex_unlock(&mutex);
+
+		(*iterations)++;
+	}
+}


### PR DESCRIPTION
Some tweaks and fixes:
1. Avoid compiler optimization in pthread_mutex4 
2. add pthread_mutex5 while at it.
3. Convert the python scripts to python3.
