### PR TITLE
Wrap Linux only tests consistently

### DIFF
--- a/tests/eventfd1.c
+++ b/tests/eventfd1.c
@@ -34,7 +34,6 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 }
 #else
 char *testcase_description = "eventfd read/write of 8 bytes";
-
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
 }

--- a/tests/fallocate2.c
+++ b/tests/fallocate2.c
@@ -1,10 +1,4 @@
-char *testcase_description = "Separate file fallocate";
-
-#if defined(__NetBSD__)
-void testcase(unsigned long long *iterations, unsigned long nr)
-{
-}
-#else
+#if __linux__
 #define _GNU_SOURCE             /* See feature_test_macros(7) */
 #include <errno.h>
 #include <fcntl.h>
@@ -15,6 +9,8 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 
 #define FILESIZE (1 * 1024 * 1024)
 #define BUFLEN (FILESIZE / 128)
+
+char *testcase_description = "Separate file fallocate";
 
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
@@ -36,5 +32,10 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 		}
 		(*iterations)++;
 	}
+}
+#else
+char *testcase_description = "Separate file fallocate";
+void testcase(unsigned long long *iterations, unsigned long nr)
+{
 }
 #endif

--- a/tests/futex3.c
+++ b/tests/futex3.c
@@ -1,7 +1,6 @@
 #ifdef __linux__
 #define _GNU_SOURCE
 #include <unistd.h>
-
 #include <sys/syscall.h>
 #include <linux/futex.h>
 

--- a/tests/tlb_flush1.c
+++ b/tests/tlb_flush1.c
@@ -7,22 +7,14 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/types.h>
-#include <sys/syscall.h>
 #include <stdio.h>
 
-#if defined(__NetBSD__)
-#include <lwp.h>
-#define gettid()  (long int)_lwp_self()
-#else
-#define gettid()  syscall(SYS_gettid)
-#endif
 #define FILESIZE (128 * 1024 * 1024)
 
 char *testcase_description = "TLB flush of separated file private mapping";
 
 void testcase(unsigned long *iteration, unsigned long nr)
 {
-	printf("thread/process number: %lu, pid: %ld\n", nr, gettid());
 	char tmpfile[] = "/tmp/willitscale.XXXXXX";
 	int fd = mkstemp(tmpfile);
 	unsigned long offset = 0;

--- a/tests/tlb_flush2.c
+++ b/tests/tlb_flush2.c
@@ -7,22 +7,14 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/types.h>
-#include <sys/syscall.h>
 #include <stdio.h>
 
-#if defined(__NetBSD__)
-#include <lwp.h>
-#define gettid()  (long int)_lwp_self()
-#else
-#define gettid()  syscall(SYS_gettid)
-#endif
 #define MEMORYSIZE (1 * 1024 * 1024)
 
 char *testcase_description = "TLB flush of anonymous memory private mapping";
 
 void testcase(unsigned long *iteration, unsigned long nr)
 {
-	printf("thread/process number: %lu, pid: %ld\n", nr, gettid());
 	unsigned long pgsize = getpagesize();
 	unsigned long i;
 

--- a/tests/tlb_flush3.c
+++ b/tests/tlb_flush3.c
@@ -7,22 +7,14 @@
 #include <string.h>
 #include <assert.h>
 #include <sys/types.h>
-#include <sys/syscall.h>
 #include <stdio.h>
 
-#if defined(__NetBSD__)
-#include <lwp.h>
-#define gettid()  (long int)_lwp_self()
-#else
-#define gettid()  syscall(SYS_gettid)
-#endif
 #define FILESIZE (128 * 1024 * 1024)
 
 char *testcase_description = "TLB flush of separated file shared mapping";
 
 void testcase(unsigned long *iteration, unsigned long nr)
 {
-	printf("thread/process number: %lu, pid: %ld\n", nr, gettid());
 	char tmpfile[] = "/tmp/willitscale.XXXXXX";
 	int fd = mkstemp(tmpfile);
 	unsigned long offset = 0;


### PR DESCRIPTION
We used #if __linux__ in some places and #if defined(__NetBSD__) in
other places.

The TLB tests went to great lengths to print the TID, which is not
necessary, so remove it.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>