### PR TITLE
Fixes case 'unlink1' leaking tmpfiles after exit

### DIFF
--- a/main.c
+++ b/main.c
@@ -18,6 +18,8 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <poll.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #define MAX_TASKS 1024
 #define CACHELINE_SIZE 128
@@ -136,6 +138,10 @@ static void kill_tasks(void)
 	for (i = 0; i < nr_threads; i++) {
 		pthread_cancel(threads[i]);
 	}
+
+	for (i = 0; i < nr_threads; i++) {
+		pthread_join(threads[i], NULL);
+	}
 }
 
 #else
@@ -215,6 +221,8 @@ static void kill_tasks(void)
 
 	for (i = 0; i < nr_pids; i++)
 		kill(pids[i], SIGTERM);
+	for (i = 0; i < nr_pids; i++)
+		waitpid(pids[i], NULL, 0);
 }
 #endif
 

--- a/tests/unlink1.c
+++ b/tests/unlink1.c
@@ -4,26 +4,51 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <string.h>
 
+#include <stdio.h>
 char *testcase_description = "Separate file open/close/unlink";
+
+#define template 	"/tmp/willitscale.XXXXXX"
+static char (*tmpfiles)[sizeof(template)];
+static int local_nr_tasks;
 
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
-	char tmpfile[] = "/tmp/willitscale.XXXXXX";
-	int fd = mkstemp(tmpfile);
-
-	assert(fd >= 0);
-	close(fd);
-	unlink(tmpfile);
+	char *tmpfile = tmpfiles[nr];
 
 	while (1) {
-		fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
+		int fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
 		assert(fd >= 0);
 		close(fd);
 		unlink(tmpfile);
 
 		(*iterations)++;
 	}
+}
 
-	unlink(tmpfile);
+void testcase_prepare(unsigned long nr_tasks)
+{
+	tmpfiles = (char(*)[sizeof(template)])malloc(sizeof(template) * nr_tasks);
+	assert(tmpfiles);
+
+	for (int i = 0; i < nr_tasks; i++) {
+		strcpy(tmpfiles[i], template);
+		char *tmpfile = tmpfiles[i];
+		int fd = mkstemp(tmpfile);
+
+		assert(fd >= 0);
+		close(fd);
+		unlink(tmpfile);
+	}
+
+	local_nr_tasks = nr_tasks;
+}
+
+void testcase_cleanup(void)
+{
+	for (int i = 0; i < local_nr_tasks; i++) {
+		unlink(tmpfiles[i]);
+	}
+	free(tmpfiles);
 }


### PR DESCRIPTION
There are two patches:
1. Adding pthread_join()/waitpid() to wait for child thread exit to prevent
race between child running case and parent doing cleanup
2. Adding a testcase_prepare()/testcase_cleanup() to cleanup the tmpfiles
in tests/unlink1.c


## Testing
### without patches:
$rm -rf /tmp/willitscale* && ./unlink1_processes -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale* > /dev/null 2>&1 && echo "Leaked"
Leaked

$rm -rf /tmp/willitscale* && ./unlink1_threads -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale* > /dev/null 2>&1 && echo "Leaked"
Leaked


### with patches
$rm -rf /tmp/willitscale* && ./unlink1_processes -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale*
ls: cannot access '/tmp/willitscale*': No such file or directory

$rm -rf /tmp/willitscale* && ./unlink1_threads -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale*
ls: cannot access '/tmp/willitscale*': No such file or directory
