### PR TITLE
Fix tmpfile leak in some test cases

### DIFF
--- a/main.c
+++ b/main.c
@@ -18,6 +18,8 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <poll.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #define MAX_TASKS 2048
 #define MAX_CACHELINE_SIZE 256
@@ -144,6 +146,10 @@ static void kill_tasks(void)
 	for (i = 0; i < nr_threads; i++) {
 		pthread_cancel(threads[i]);
 	}
+
+	for (i = 0; i < nr_threads; i++) {
+		pthread_join(threads[i], NULL);
+	}
 }
 
 #else
@@ -223,6 +229,8 @@ static void kill_tasks(void)
 
 	for (i = 0; i < nr_pids; i++)
 		kill(pids[i], SIGTERM);
+	for (i = 0; i < nr_pids; i++)
+		waitpid(pids[i], NULL, 0);
 }
 #endif
 

--- a/tests/dup1.c
+++ b/tests/dup1.c
@@ -10,6 +10,7 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 	int fd = mkstemp(tmpfile);
 
 	assert(fd >= 0);
+	unlink(tmpfile);
 
 	while (1) {
 		int fd2 = dup(fd);
@@ -21,5 +22,4 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 	}
 
 	close(fd);
-	unlink(tmpfile);
 }

--- a/tests/open2.c
+++ b/tests/open2.c
@@ -6,20 +6,42 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <limits.h>
+#include <string.h>
 
 char *testcase_description = "Separate file open/close in different directories";
 
-void testcase(unsigned long long *iterations, unsigned long nr)
+#define template 	"/tmp/willitscale.XXXXXX"
+static char (*tmpdirs)[sizeof(template)];
+static unsigned long local_nr_tasks;
+
+void testcase_prepare(unsigned long nr_tasks)
 {
-	char tmpdir[] = "/tmp/willitscale.XXXXXX";
+	int i;
+	tmpdirs = (char(*)[sizeof(template)])malloc(sizeof(template) * nr_tasks);
+	assert(tmpdirs);
+
 	char tmpfile[PATH_MAX];
 	int fd;
 
-	assert(mkdtemp(tmpdir) != NULL);
-	sprintf(tmpfile, "%s/willitscale", tmpdir);
-	fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
-	assert(fd >= 0);
-	close(fd);
+	for (i = 0; i < nr_tasks; i++) {
+		strcpy(tmpdirs[i], template);
+		char *tmpdir = tmpdirs[i];
+		assert(mkdtemp(tmpdir) != NULL);
+		sprintf(tmpfile, "%s/willitscale", tmpdir);
+		fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
+		assert(fd >= 0);
+		close(fd);
+	}
+
+	local_nr_tasks = nr_tasks;
+}
+
+
+void testcase(unsigned long long *iterations, unsigned long nr)
+{
+	int fd;
+	char tmpfile[PATH_MAX];
+	sprintf(tmpfile, "%s/willitscale", tmpdirs[nr]);
 
 	while (1) {
 		fd = open(tmpfile, O_RDWR);
@@ -28,4 +50,18 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 
 		(*iterations)++;
 	}
+}
+
+
+void testcase_cleanup(void)
+{
+	int i;
+	char tmpfile[PATH_MAX];
+
+	for (i = 0; i < local_nr_tasks; i++) {
+		sprintf(tmpfile, "%s/willitscale", tmpdirs[i]);
+		unlink(tmpfile);
+		rmdir(tmpdirs[i]);
+	}
+	free(tmpdirs);
 }

--- a/tests/unlink1.c
+++ b/tests/unlink1.c
@@ -4,26 +4,55 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <string.h>
 
 char *testcase_description = "Separate file open/close/unlink";
 
+#define template 	"/tmp/willitscale.XXXXXX"
+static char (*tmpfiles)[sizeof(template)];
+static int local_nr_tasks;
+
+
+void testcase_prepare(unsigned long nr_tasks)
+{
+	int i;
+	tmpfiles = (char(*)[sizeof(template)])malloc(sizeof(template) * nr_tasks);
+	assert(tmpfiles);
+
+	for (i = 0; i < nr_tasks; i++) {
+		strcpy(tmpfiles[i], template);
+		char *tmpfile = tmpfiles[i];
+		int fd = mkstemp(tmpfile);
+
+		assert(fd >= 0);
+		close(fd);
+		unlink(tmpfile);
+	}
+
+	local_nr_tasks = nr_tasks;
+}
+
+
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
-	char tmpfile[] = "/tmp/willitscale.XXXXXX";
-	int fd = mkstemp(tmpfile);
-
-	assert(fd >= 0);
-	close(fd);
-	unlink(tmpfile);
+	char *tmpfile = tmpfiles[nr];
 
 	while (1) {
-		fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
+		int fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
 		assert(fd >= 0);
 		close(fd);
 		unlink(tmpfile);
 
 		(*iterations)++;
 	}
+}
 
-	unlink(tmpfile);
+
+void testcase_cleanup(void)
+{
+	int i;
+	for (i = 0; i < local_nr_tasks; i++) {
+		unlink(tmpfiles[i]);
+	}
+	free(tmpfiles);
 }

--- a/tests/unlink2.c
+++ b/tests/unlink2.c
@@ -6,16 +6,42 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <assert.h>
+#include <string.h>
 
 char *testcase_description = "Separate file open/close/unlink in different directories";
 
+#define template 	"/tmp/willitscale.XXXXXX"
+static char (*tmpdirs)[sizeof(template)];
+static unsigned long local_nr_tasks;
+
+void testcase_prepare(unsigned long nr_tasks)
+{
+	int i;
+	tmpdirs = (char(*)[sizeof(template)])malloc(sizeof(template) * nr_tasks);
+	assert(tmpdirs);
+
+	char tmpfile[PATH_MAX];
+	int fd;
+
+	for (i = 0; i < nr_tasks; i++) {
+		strcpy(tmpdirs[i], template);
+		char *tmpdir = tmpdirs[i];
+		assert(mkdtemp(tmpdir) != NULL);
+		sprintf(tmpfile, "%s/willitscale", tmpdir);
+		fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
+		assert(fd >= 0);
+		close(fd);
+	}
+
+	local_nr_tasks = nr_tasks;
+}
+
+
 void testcase(unsigned long long *iterations, unsigned long nr)
 {
-	char tmpdir[] = "/tmp/willitscale.XXXXXX";
 	char tmpfile[PATH_MAX];
 
-	assert(mkdtemp(tmpdir) != NULL);
-	sprintf(tmpfile, "%s/willitscale", tmpdir);
+	sprintf(tmpfile, "%s/willitscale", tmpdirs[nr]);
 
 	while (1) {
 		int fd = open(tmpfile, O_RDWR|O_CREAT, 0600);
@@ -25,4 +51,18 @@ void testcase(unsigned long long *iterations, unsigned long nr)
 
 		(*iterations)++;
 	}
+}
+
+
+void testcase_cleanup(void)
+{
+	int i;
+	char tmpfile[PATH_MAX];
+
+	for (i = 0; i < local_nr_tasks; i++) {
+		sprintf(tmpfile, "%s/willitscale", tmpdirs[i]);
+		unlink(tmpfile);
+		rmdir(tmpdirs[i]);
+	}
+	free(tmpdirs);
 }


### PR DESCRIPTION
There are two kind of  patches in this patch set:

- Adding pthread_join()/waitpid() to wait for child thread exit to prevent
race between child running case and parent doing cleanup
- Adding a testcase_prepare()/testcase_cleanup() to cleanup the tmpfiles
in the following test cases: unlink1/unlink2/open1/open2/dup1


Testing
```bash
for i in *_processes; do
        TESTCASE=`basename $i _processes`
        rm -rf /tmp/willitscale* && ./${TESTCASE}_threads -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale* > /dev/null 2>&1 && echo ${TESTCASE}_threads leaked
        rm -rf /tmp/willitscale* && ./${TESTCASE}_processes -t 32 -s 1 > /dev/null && ls -l /tmp/willitscale* > /dev/null 2>&1 && echo ${TESTCASE}_processes leaked
done
```

- without this patch set:
dup1_threads leaked
dup1_processes leaked
open1_threads leaked
open1_processes leaked
open2_threads leaked
open2_processes leaked
unlink1_threads leaked
unlink1_processes leaked
unlink2_threads leaked
unlink2_processes leaked



- with this patch set:  no leak

