### PR TITLE
kill tasks before cleaning up topology structures

### DIFF
--- a/main.c
+++ b/main.c
@@ -414,13 +414,14 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	kill_tasks();
+
 	for (i = 0; i < opt_tasks; i++) {
 		hwloc_bitmap_free(args[i].cpuset);
 		hwloc_topology_destroy(args[i].topology);
 	}
 	free(args);
 
-	kill_tasks();
 	testcase_cleanup();
 	exit(0);
 }


### PR DESCRIPTION
On a big box, it is taking quite a while to clean up the topology
structures because the child processes are still running. Kill them
first.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>