### PR TITLE
Set cancelability type to PTHREAD_CANCEL_ASYNCHRONOUS

### DIFF
--- a/main.c
+++ b/main.c
@@ -120,6 +120,8 @@ static void *pre_trampoline(void *p)
 		exit(1);
 	}
 
+	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
+
 	return testcase_trampoline(args);
 }
 


### PR DESCRIPTION
Some thread tests are taking a long time to exit because we never call
a function that is a cancellation point. Switch to PTHREAD_CANCEL_ASYNCHRONOUS
so we exit straight away.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>