### PR TITLE
Get alloca def via stdlib.h, since BSD systems don't have alloca.h

### DIFF
--- a/tests/pthread_mutex4.c
+++ b/tests/pthread_mutex4.c
@@ -1,6 +1,6 @@
 #define _GNU_SOURCE
 #include <pthread.h>
-#include <alloca.h>
+#include <stdlib.h>
 
 char *testcase_description = "Contended pthread mutex with local update";
 


### PR DESCRIPTION
BSD: alloca is defined in stdlib.h. Linux: glibc's stdlib.h includes alloca.h.  

Compiles successfully on Debian 10 and NetBSD 9.99.68.

I verified with objdump -d that the increment of val is still not optimised away.