### PR TITLE
poll2: update rlim.rlim_cur if it's too low

### DIFF
--- a/tests/poll2.c
+++ b/tests/poll2.c
@@ -19,9 +19,12 @@ void testcase_prepare(unsigned long nr_tasks)
 	rlim_t new_lim = (NR_FILES + 10) * nr_procs;
 
 	getrlimit(RLIMIT_NOFILE, &rlim);
-	if( rlim.rlim_max < new_lim) {
+	if (rlim.rlim_max < new_lim) {
 		rlim.rlim_cur = new_lim;
 		rlim.rlim_max = new_lim;
+	}
+	if (rlim.rlim_cur < new_lim) {
+		rlim.rlim_cur = new_lim;
 	}
 	assert(setrlimit(RLIMIT_NOFILE, &rlim) == 0);
 }


### PR DESCRIPTION
I saw some assertion failures on a test machine where the hard limit
for open files was adequate but the soft limit was too low. The
startup code only adjust the limits if the hard limit is inadequate.
Make it also check, and if necessary increase, the soft limit.

We make this a separate test so we don't accidentally lower the hard
limit by mistake!

Signed-off-by: Daniel Axtens <dja@axtens.net>