### PR TITLE
Add a better brk() test, from Matthew Wilcox

### DIFF
--- a/tests/brk2.c
+++ b/tests/brk2.c
@@ -1,0 +1,21 @@
+#include <assert.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+char *testcase_description = "brk unshared increase/decrease of one page";
+
+void testcase(unsigned long long *iterations, unsigned long nr)
+{
+	unsigned long page_size = getpagesize();
+	void *addr = sbrk(page_size) + page_size;
+
+	while (1) {
+		addr += page_size;
+		assert(brk(addr) == 0);
+
+		addr -= page_size;
+		assert(brk(addr) == 0);
+
+		(*iterations) += 2;
+	}
+}


### PR DESCRIPTION
The gory details from Willy:

Linux has this horrendously complicated anon_vma structure that you don't
care about, but the upshot is that after calling fork(), each process
that calls brk() gets a _new_ VMA created.  That is, after calling brk()
the first time, the process address space looks like this:

557777fab000-557777ff0000 rw-p 00000000 00:00 0                          [heap]
557777ff0000-557777ff1000 rw-p 00000000 00:00 0                          [heap]

so what brk1 is actually testing is how long it takes to create & destroy
a new VMA.  This does not match what most programs do -- most will call
exec() which resets the anon_vma structures and starts each program off
with its own heap.  And if you do have a multi-process program which
uses brk(), chances are it doesn't just oscillate betwee zero and one
extra pages of heap compared to its parent.

A better test starts out by allocating one page on the heap and then
throbs between one and two pages instead of throbbing between zero and
one page.  That means we're actually testing expanding and contracting
the heap instead of creating and destroying a new heap.

For realism, I wanted to add actually accessing the memory in the new
heap, but that doesn't work for the threaded case -- another thread
might remove the memory you just allocated while you're allocating it.
Threaded programs give each thread its own heap anyway, so this is
kind of a pointless syscall to ask about its threaded scalability.

Anyway, here's brk2.c.  It is not very different from brk1.c, but the
performance results are quite different (actually worse by about 10-15%).

Signed-off-by: Anton Blanchard <anton@ozlabs.org>