### PR TITLE
Use MAP_ANONYMOUS|MAP_SHARED instead of unlinked file in /tmp

### DIFF
--- a/main.c
+++ b/main.c
@@ -30,6 +30,24 @@ extern void __attribute__((weak)) testcase_prepare(unsigned long nr_tasks) { }
 extern void __attribute__((weak)) testcase_cleanup(void) { }
 extern void *testcase(unsigned long long *iterations, unsigned long nr);
 
+#ifdef __linux__
+static char *initialise_shared_area(unsigned long size)
+{
+	char *m;
+	int page_size = getpagesize();
+
+	/* Align to page boundary */
+	size = (size + page_size-1) & ~(page_size-1);
+
+	m = mmap(NULL, size, PROT_READ|PROT_WRITE, MAP_ANONYMOUS|MAP_SHARED, -1, 0);
+	if (m == MAP_FAILED) {
+		perror("mmap");
+		exit(1);
+	}
+
+	return m;
+}
+#else
 static char *initialise_shared_area(unsigned long size)
 {
 	char template[] = "/tmp/shared_area_XXXXXX";
@@ -65,6 +83,7 @@ static char *initialise_shared_area(unsigned long size)
 
 	return m;
 }
+#endif
 
 static void usage(char *command)
 {


### PR DESCRIPTION
On a large machine we noticed the shared mapping for statistics
gathering was causing significant amounts of file I/O. I have no idea
why I used an unlinked file to create the shared area in
initialise_shared_area().

Use a MAP_ANONYMOUS|MAP_SHARED mmap instead. I've made it as Linux only
for now.

Signed-off-by: Anton Blanchard <anton@ozlabs.org>