### PR TITLE
Add a new page fault test case page_fault4

### DIFF
--- a/tests/page_fault4.c
+++ b/tests/page_fault4.c
@@ -1,0 +1,35 @@
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <assert.h>
+
+#define MEMSIZE (128 * 1024 * 1024)
+
+char *testcase_description = "Separate file private mapping page read fault";
+
+void testcase(unsigned long long *iterations, unsigned long nr)
+{
+	char tmpfile[] = "/tmp/willitscale.XXXXXX";
+	int fd = mkstemp(tmpfile);
+	unsigned long pgsize = getpagesize();
+
+	assert(fd >= 0);
+	assert(ftruncate(fd, MEMSIZE) == 0);
+	unlink(tmpfile);
+
+	while (1) {
+		unsigned long i;
+		char cc __attribute__((unused));
+
+		char *c = mmap(NULL, MEMSIZE, PROT_READ|PROT_WRITE,
+			       MAP_PRIVATE, fd, 0);
+		assert(c != MAP_FAILED);
+
+		for (i = 0; i < MEMSIZE; i += pgsize) {
+			cc = *(volatile char *)(c + i);
+			(*iterations)++;
+		}
+
+		munmap(c, MEMSIZE);
+	}
+}


### PR DESCRIPTION
It's like page_fault2 but the file read fault is triggered instead of file write fault.

The improvement in file read fault path can be detected by this new test case.

Signed-off-by: Yin Fengwei <fengwei.yin@intel.com>